### PR TITLE
Adding support for Trufflehog V3

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,25 @@ Contribution is always welcome! Please feel free to report issues on Github and 
 ## 📌 Ideas to Start on
 
 # Using
-For Trufflehog v2
-$> ./convert-rules.py --db ../db/rules-stable.yml --type trufflehog
-For Gitleaks
-$> ./convert-rules.py --db ../db/rules-stable.yml --type  gitleaks
 
-Optional:
---export - Set filename, extension will be added by type (gitleaks = toml, trufflehog = json)
+For Trufflehog v2
+```shell
+./scripts/convert-rules.py --db ./db/rules-stable.yml --type trufflehogv2
+```
+
+For Trufflehog v3
+```shell
+./scripts/convert-rules.py --db ./db/rules-stable.yml --type trufflehogv3
+```
+
+For Gitleaks
+```shell
+./scripts/convert-rules.py --db ./db/rules-stable.yml --type  gitleaks
+```
+
+
+**Optional**:
+--export - Set filename, extension will be added by type (gitleaks = toml, trufflehogV2 = json, trufflehogV3 = yaml)
 
 Would like to contribute to secrets-patterns-db? Here are some ideas that you may start with:
 

--- a/scripts/convert-rules.py
+++ b/scripts/convert-rules.py
@@ -3,9 +3,10 @@ import sys
 import json
 import yaml
 import argparse
+import re
 
 
-def trufflehog_output(y):
+def trufflehogv2_output(y):
     output = {}
     for i in y["patterns"]:
         if i["pattern"]["confidence"] != "high":
@@ -14,6 +15,20 @@ def trufflehog_output(y):
     
     return json.dumps(output, indent=4, sort_keys=True)
     
+
+def trufflehogv3_output(y):
+    output = []
+    for i in y["patterns"]:
+        each_name = i["pattern"]["name"]
+        each_regex = i["pattern"]["regex"]
+        # each_confidence = i["pattern"]["confidence"]
+
+        keywords_list = re.sub(r'[.,;:?!_\-]', ' ', each_name).split()
+        output.append({'name': each_name, 'keywords': list(keywords_list),
+                      'regex': {each_name: each_regex}})
+
+    return output
+
 
 def gitleaks_output(y):
     s = 'title = "gitleaks config"'
@@ -37,15 +52,20 @@ def main(arg):
     
     output_string = ""
     ext_string = ""
-    if arg.output_type == "trufflehog":
-        output_string = trufflehog_output(y)
+    if arg.output_type == "trufflehogv2":
+        output_string = trufflehogv2_output(y)
         ext_string = "json"
     elif arg.output_type == "gitleaks":
         output_string = gitleaks_output(y)
         ext_string = "toml"
+    elif arg.output_type == "trufflehogv3":
+        output_string = yaml.dump(trufflehogv3_output(y), sort_keys=False)
+        ext_string = "yml"
     
     if arg.export_filename is not None:              
         f = open(f"{arg.export_filename}.{ext_string}", "w")
+        if arg.output_type == "trufflehogv3" :
+            f.write('detectors:\n')
         f.write(output_string)
         f.close()
     else:
@@ -53,10 +73,10 @@ def main(arg):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Convert yaml database file to rules for trufflehog or gitleaks')
+    parser = argparse.ArgumentParser(description='Convert yaml database file to rules for trufflehogv2, trufflehogv3 or gitleaks')
     parser.add_argument("--db", dest = "database_file", required = True, help = "The yaml database file")
-    parser.add_argument("--type", dest= "output_type", required = True, choices=['trufflehog', 'gitleaks'], help = "Supported output types: trufflehog, gitleaks")
-    parser.add_argument('--export', dest="export_filename", help = "Give filename, extension toml/json will be added")
+    parser.add_argument("--type", dest= "output_type", required = True, choices=['trufflehogv2', 'trufflehogv3', 'gitleaks'], help = "Supported output types: trufflehog, gitleaks")
+    parser.add_argument('--export', dest="export_filename", help = "Give filename, extension toml/json/yaml will be added")
     args = parser.parse_args()
     
     main(args)


### PR DESCRIPTION
The new-ish Trufflehog V3 needs rules in YAML format as specified here: https://docs.trufflesecurity.com/docs/configuration/detectors/

Just as a note, this is a sample new rules file:

```yaml
detectors:
- name: generic-api-key
  keywords:
  - key
  - api
  - token
  - secret
  - client
  - passwd
  - password
  - auth
  - access
  regex:
    generic-api-key: "(?i)([sample regex]?:]|$)"
```


I updated the `convert-rules.py` so that it now accepts trufflehogV2, gitleaks and the new trufflehogV3. Those rules can now be used with the latest release of trufflehog just using the flag `--config /path/to/config.yml`, being the `config.yml` the file that the  `convert-rules.py` script outputs.




I also updated the readme for clarification (the current readme has the usage commands in LaTeX format somehow...) and because the old `--type trufflehog` is now separated in  `--type trufflehogv2` and `--type trufflehogv3`  respectively.


Keep up the good work =)