### PR TITLE
add pattern: AWS Secret Key ID value

### DIFF
--- a/db/rules-stable.yml
+++ b/db/rules-stable.yml
@@ -16,6 +16,10 @@ patterns:
       regex: (A3T[A-Z0-9]|AKIA|AGPA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}
       confidence: high
   - pattern:
+      name: AWS Secret Key ID Value
+      regex: (?<![A-Za-z0-9/+=])[A-Za-z0-9/+=]{40}(?![A-Za-z0-9/+=])
+      confidence: high
+  - pattern:
       name: AWS AppSync GraphQL Key
       regex: da2-[a-z0-9]{26}
       confidence: high


### PR DESCRIPTION
Regex taken from AWS blog: https://aws.amazon.com/blogs/security/a-safer-way-to-distribute-aws-credentials-to-ec2/