### PR TITLE
fix Slack pattern

### DIFF
--- a/db/rules-stable.yml
+++ b/db/rules-stable.yml
@@ -2957,7 +2957,7 @@ patterns:
       confidence: high
   - pattern:
       name: Slack
-      regex: xox[baprs]-[0-9a-zA-Z]{10,48}
+      regex: xox[baprs]-[0-9a-zA-Z-]{10,72}
       confidence: high
   - pattern:
       name: Slack Token


### PR DESCRIPTION
The previous Slack regex worked incorrectly due to the presence of hyphens in between and length limit:
`regex: xox[baprs]-[0-9a-zA-Z]{10,48}`

The new regex will match for hyphens as well as the new length:
`regex: xox[baprs]-[0-9a-zA-Z-]{10,72}`

This will identify both the User OAuth Token and Bot User OAuth Token